### PR TITLE
proper handling of chromosome check.

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -42,8 +42,7 @@ rule bam_stats:
         chrNamesNCBI=$(cut -f2 {input.ucsc2ncbi} | tr '\n' '|')
     
         # identify chromosome format
-        bam_chr=$(samtools idxstats {input.bam} | grep chr || true | wc -l)
-        if [ $bam_chr -ne 0 ]
+        if if samtools idxstats {input.bam} | grep "^chr" -qP;
         then
             chrNames=$chrNamesUCSC
         else


### PR DESCRIPTION
this is the error when running with UCSC format

```
# bam_chr=$(samtools idxstats Data/rna_bam/HG00103.4.M_120208_3_chr21.bam | grep chr || true | wc -l)
# [ $bam_chr -ne 0 ] || echo "false" && echo "true"
bash: [: too many arguments
false
true
```